### PR TITLE
[6-55] background color for odd rows of tables

### DIFF
--- a/exalearn-ui/src/app/components/data-table/data-table.component.scss
+++ b/exalearn-ui/src/app/components/data-table/data-table.component.scss
@@ -37,6 +37,10 @@ td:last-child {
 	margin-right: -18px;
 }
 
+::ng-deep tbody tr:nth-child(odd) {
+	background-color: #f6f6f6;
+}
+
 ::ng-deep tbody tr.mat-row {
 	height: 40px;
 }


### PR DESCRIPTION
Added background-color to odd rows of tables

![tables 1](https://user-images.githubusercontent.com/86977404/128986982-146eb2bf-51cd-48a5-8fc8-f7a7a6811a6c.JPG)
![tables 2](https://user-images.githubusercontent.com/86977404/128986988-35094c87-678a-40c1-bde6-691004721837.JPG)
