### PR TITLE
[8-19] modify button styles on modals

### DIFF
--- a/exalearn-ui/src/app/components/start-check-test/start-check-test.component.html
+++ b/exalearn-ui/src/app/components/start-check-test/start-check-test.component.html
@@ -6,7 +6,7 @@
 		</button>
 	</div>
 	<div mat-dialog-actions class="cancel-btn">
-		<button mat-raised-button color="primary" (click)="closeCheckTest()">
+		<button mat-raised-button color="warn" (click)="closeCheckTest()">
 			{{ 'START_CHECK_MODAL.START_CHECK_NO' | translate }}
 		</button>
 	</div>

--- a/exalearn-ui/src/app/components/submit-test-modal/submit-test-modal.component.html
+++ b/exalearn-ui/src/app/components/submit-test-modal/submit-test-modal.component.html
@@ -6,7 +6,7 @@
 		</button>
 	</div>
 	<div mat-dialog-actions class="cancel-btn">
-		<button mat-raised-button color="primary" (click)="closeDialog()">
+		<button mat-raised-button color="warn" (click)="closeDialog()">
 			{{ 'FINISH_TEST_MODAL.BUTTON_NO' | translate }}
 		</button>
 	</div>


### PR DESCRIPTION
Buttons on modals should have different styles. Detected two cases where both buttons had blue bg. Changed from blue to red:

![modal-buttons-01](https://user-images.githubusercontent.com/86977404/130733545-e0cf10f2-5a63-433b-8327-3067e75c0be8.JPG)
![modal-buttons-02](https://user-images.githubusercontent.com/86977404/130733547-09e6608a-e4e8-445d-8536-fae463fd9da4.JPG)
