### PR TITLE
[8-20] fix button styles after opening/closing a modal

### DIFF
--- a/exalearn-ui/src/app/components/data-table/data-table.component.ts
+++ b/exalearn-ui/src/app/components/data-table/data-table.component.ts
@@ -75,7 +75,9 @@ export class DataTableComponent implements AfterViewInit, OnInit {
 		this.dialog.open(AssignTestModalComponent, {
 			width: '100%',
 			maxWidth: 500,
-			data: el
+			data: el,
+			autoFocus: false,
+			restoreFocus: false
 		});
 	}
 
@@ -83,7 +85,9 @@ export class DataTableComponent implements AfterViewInit, OnInit {
 		this.dialog.open(ViewTestModalComponent, {
 			width: '100%',
 			maxWidth: 500,
-			data: el
+			data: el,
+			autoFocus: false,
+			restoreFocus: false
 		});
 	}
 
@@ -91,7 +95,9 @@ export class DataTableComponent implements AfterViewInit, OnInit {
 		this.dialog.open(StartTestModalComponent, {
 			width: '100%',
 			maxWidth: 500,
-			data: el
+			data: el,
+			autoFocus: false,
+			restoreFocus: false
 		});
 	}
 
@@ -99,7 +105,9 @@ export class DataTableComponent implements AfterViewInit, OnInit {
 		this.dialog.open(StartCheckTestComponent, {
 			width: '100%',
 			maxWidth: 500,
-			data: el
+			data: el,
+			autoFocus: false,
+			restoreFocus: false
 		});
 	}
 
@@ -107,7 +115,9 @@ export class DataTableComponent implements AfterViewInit, OnInit {
 		this.dialog.open(ViewTestModalComponent, {
 			width: '100%',
 			maxWidth: 500,
-			data: el
+			data: el,
+			autoFocus: false,
+			restoreFocus: false
 		});
 	}
 	openEditQuestion(question: CheckCoachQuestion): void {
@@ -118,7 +128,9 @@ export class DataTableComponent implements AfterViewInit, OnInit {
 				modalHeader: 'QUESTION_EDIT_MODAL.EDIT_OR_DELETE_QUESTION',
 				questionName: 'QUESTION_EDIT_MODAL.QUESTION',
 				answer: question
-			}
+			},
+			autoFocus: false,
+			restoreFocus: false
 		});
 	}
 	passedColor(passed: string) {

--- a/exalearn-ui/src/app/components/finish-test-button/finish-test-button.component.ts
+++ b/exalearn-ui/src/app/components/finish-test-button/finish-test-button.component.ts
@@ -12,6 +12,6 @@ export class FinishTestButtonComponent {
 	constructor(public submit: SubmitTestService, public dialog: MatDialog) {}
 
 	public openDialog() {
-		this.dialog.open(SubmitTestModalComponent);
+		this.dialog.open(SubmitTestModalComponent, { autoFocus: false, restoreFocus: false });
 	}
 }

--- a/exalearn-ui/src/app/components/question/question.component.ts
+++ b/exalearn-ui/src/app/components/question/question.component.ts
@@ -42,7 +42,8 @@ export class QuestionComponent implements DoCheck {
 			data: {
 				passedTestId: this.testPassedId,
 				questionId: this.question.id
-			}
+			},
+			restoreFocus: false
 		});
 		dialogRef.afterClosed().subscribe((message) => {
 			this.reportedMessage = message;


### PR DESCRIPTION
Buttons' had weird styles after opening and closing modals. Turned off the "autoFocus" and "restoreFocus" options while opening modals. Tried to find all modals, if any was missed, they will be fixed as well upon indication.